### PR TITLE
removed header import from BaseLayout.js page

### DIFF
--- a/pages/components/layouts/BaseLayouts.js
+++ b/pages/components/layouts/BaseLayouts.js
@@ -1,10 +1,9 @@
-import Header from '../shared/Header';
 
 const BaseLayout = (props) => {
   const { className, user, loading, children } = props;
   return (
     <div className="layout-container">
-      <Header user={user} loading={loading} />
+      {/* <Header user={user} loading={loading} /> */}
       <main className={`cover ${className}`}>
         <div className="wrapper">{children}</div>
       </main>


### PR DESCRIPTION
Just commented out the line where we add the header component and removed the import statement so the project could build 